### PR TITLE
Fixed broken Idaho.gov link and adjusted formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [Media.io](https://www.media.io/app/removeWatermark) | removes bright/large objects from images |
 | [Replicate](https://replicate.com/tencentarc/gfpgan) | restores blurry/hazy/damaged photos of faces (potentially other images) |
 | [TheinPaint](https://theinpaint.com/) | removes objects from images |
-| [PimEyes](https://pimeyes.com/en) | facial recognition AI that is terrifyingly accurate, compares target to images all over the web |
+| [PimEyes](https://pimeyes.com/en) | facial recognition AI that is terrifyingly accurate, compares the target to images all over the web |
 | [CarLogos](https://www.carlogos.org/car-brands-a-z/) | database of all car manufacturers worldwide and their logos |
 | [PhotOSINT](https://chrome.google.com/webstore/detail/photosint/gonhdjmkgfkokhkflfhkbiagbmoolhcd/related?hl=nl) | scans images on webpage for exif data |
-| [Calculator IPVM](https://calculator.ipvm.com/) | shows the view of how a set-up camera would like using google map data |
+| [Calculator IPVM](https://calculator.ipvm.com/) | shows the view of how a set-up camera would look using Google Maps data |
 | [Commercial Truck Trader](https://www.commercialtrucktrader.com/) | database of all commercial trucks in US |
 | [Plate Recognition AI](https://github.com/winter2897/Real-time-Auto-License-Plate-Recognition-with-Jetson-Nano/blob/main/doc/dataset.md) | recognizes license plates within view of camera |
 
@@ -29,17 +29,17 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [License Plate Data](https://theinpaint.com/) | finds vehicle information from license plate number and state |
 | [Numberogram](https://play.google.com/store/apps/details?id=ru.drom.numbers&referrer=utm_source%3Dwebnomerogramfooter%26utm_medium%3Dfree%26utm_campaign%3Dbanner) | searches Russian license plate numbers |
 | [License Plate Map: Americas](https://www.reddit.com/r/MapPorn/comments/dc9s85/license_plates_of_the_americas/) | 2019 overhead map of license plates by state/country/province |
-| [License Plate Map: Europe](https://www.reddit.com/r/MapPorn/comments/d51jr0/car_plates_in_europe/ ) | 2019 overhead map of license plates in europe by country/province |
+| [License Plate Map: Europe](https://www.reddit.com/r/MapPorn/comments/d51jr0/car_plates_in_europe/ ) | 2019 overhead map of license plates in Europe by country/province |
 | [License Plate Map: Asia](https://www.reddit.com/r/MapPorn/comments/d4ys24/license_plates_of_asia_map/) | 2019 overhead map of license plates in Asia |
 | [AutoTraveller](https://autotraveler.ru/en/spravka/vehicle-registration-codes-in-the-world.html#.Y3R6BnbMJPY) | description/images of license plates and registration display regulations based on country |
 | [Venicle Search](https://cipher387.github.io/venicle_number_search_toolbox/) | searches information related to venicle numbers in 14 different countries |
 | [NCSL](https://www.ncsl.org/research/transportation/license-plate-information.aspx) | summary of US license plate display regulations by state |
-| [Italy Insurance Control](https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-copertura-rc) | controls insurance validity of vehicle with italian plate number, comprehensive of insurance authority and insurance end date
+| [Italy Insurance Control](https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-copertura-rc) | controls insurance validity of a vehicle with an Italian plate number, comprehensive of insurance authority and insurance end date
 | [Italy Emission Class](https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-classe-ambientale-veicolo) | emission class of vehicle with italian plate number
-| [Italy Maintenance Control](https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-ultima-revisione) | gives information about last government-forced check of car (4 years for new cars, after every 2 years), including km detected at time of check
+| [Italy Maintenance Control](https://www.ilportaledellautomobilista.it/web/portale-automobilista/verifica-ultima-revisione) | gives information about the last government-forced check of a car (4 years for new cars, after every 2 years), including km detected at the time of the check
 | [Finnik](https://finnik.nl/en) | searches for information related to license plates in various European countries |
-| [Netherlands License Plate Dataset](https://opendata.rdw.nl/Voertuigen/Open-Data-RDW-Gekentekende_voertuigen/m9d7-ebf2) | license plate dataset of 15 million Netherland license plates, including a mind-boggling amount of information related to them |
-| [Intel Technique's Search Tool](https://inteltechniques.com/tools/Vehicle.html) | searches for information related to license plates in US/Canada. This is part of an OSINT framework that also offers VIN searches and other tools |
+| [Netherlands License Plate Dataset](https://opendata.rdw.nl/Voertuigen/Open-Data-RDW-Gekentekende_voertuigen/m9d7-ebf2) | license plate dataset of 15 million Netherlands license plates, including a mind-boggling amount of information related to them |
+| [Intel Technique's Search Tool](https://inteltechniques.com/tools/Vehicle.html) | searches for information related to license plates in the US and Canada. This is part of an OSINT framework that also offers VIN searches and other tools |
 | [Vic Roads](https://www.vicroads.vic.gov.au/registration/buy-sell-or-transfer-a-vehicle/check-vehicle-registration/vehicle-registration-enquiry) | Victoria vehicle registry (AU)|
 | [SivAuto.fr](https://siv-auto.fr/index.php) | France license plates search tool |
 | [Queensland.gov](https://www.qld.gov.au/transport/terms-check-rego) | Queensland license plate registry |
@@ -47,7 +47,7 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [Autocode](https://avtocod.ru/) | Russian number plate search tool |
 | [Eteenindus](https://eteenindus.mnt.ee/public/soidukTaustakontroll.jsf) | Estonia plate registry |
 | [STKonline](https://stkonline.sk/spz) | Slovakia plate search tool |
-| [DigitalService.dk](https://digitalservicebog.dk/) | plate search for Denmark, Swedan, and Norway, including a few other countries |
+| [DigitalService.dk](https://digitalservicebog.dk/) | plate search for Denmark, Sweden, and Norway, including a few other countries |
 | [MTSBU](https://policy-web.mtsbu.ua/Search/Main/en) | Ukraine license plate search tool (use at own risk, site is safe as of 11//19/2022 but conflict may affect this) |
 | [Wisconsin License Plate Search](https://trust.dot.state.wi.us/pinq/PinqServlet?whoami=pinqp1) | Offical Wisconsin search tool for license plates |
 | [First Check](https://www.firstcheck.co.za/) | South Africa number plate search tool |
@@ -56,7 +56,7 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [Itarga](https://apps.apple.com/it/app/itarga-verify-license-plate/id1222570860?l=en) | Italy plate search tool for iOS |
 | [Costco](https://tires.costco.com/) | shows make/model of vehicle from VIN/plate |
 | [Plate Recognizer](https://platerecognizer.com/) | license plate decoder |
-| [AutoCheck](https://www.autocheck.com/vehiclehistory/autocheck-score) | offical Experian plate/vin search tool, scores results based on number of owners, mileage, age, and other info |
+| [AutoCheck](https://www.autocheck.com/vehiclehistory/autocheck-score) | official Experian plate/vin search tool, scores results based on number of owners, mileage, age, and other info |
 | [egov.kz](https://egov.kz/cms/ru/articles/vehicle/grnz) | kazakhstan plate regulations and information |
 | [Kaggle](https://www.kaggle.com/datasets/elmehditaf96/moroccan-vehicle-registration-plates) | Morocco license plate dataset |
 | [HowsMyDrivingNY](https://howsmydrivingny.nyc/k36e7jzm) | violation search tool for NYC |
@@ -64,33 +64,33 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [DC.gov](https://prodpci.etimspayments.com/pbw/include/dc_parking/input.jsp?ticketType=P) | Washington DC violation verification |
 | [ct.gov](https://dmvcivls-wselfservice.ct.gov/Registration/VerifyRegistration) | Connecticut vehicle verification |
 | [Honolulu Motor Vehicle Inquiry](https://mvinquiry.hnl.info/title) | Hawaii vehicle verification |
-| [Idaho.gov](https://www.accessidaho.org/itd/driver/registration/status) | Idaho vehicle verification |
+| [Idaho Transportation Department Online Services](https://tyleridaho.com/itd/driver/registration/status) | Idaho vehicle verification |
 | [Oregon Semi-Truck Search](https://www.oregontruckingonline.com/cf/MCAD/pubMetaEntry/carrierInfoByVeh/) | Oregon semi-truck database |
-| [Mexico.gob](http://www2.repuve.gob.mx:8080/ciudadania/servletconsulta)| Mexico license plate search tool |
-| [Ghana Opera News](https://gh.opera.news/gh/en/auto/c4c2fcb2873ee5c189b5ede517b93edd)| list of Ghana license platea area codes |
-| [MPWT.gov](https://www.mpwt.gov.kh/en/home)| search tool for Cambodian number plates (must use VPN to access) |
-| [Parkingfee.gov](https://parkingfee.pma.gov.taipei/Fee/EnQuery)| shows information if parking fee is associated with number plate(Taipei) |
-| [TTCarLicense](https://apps.apple.com/us/app/ttcarlicense/id1450083022)| Myanmar license plate search app for macOS |
-| [EpicVin.com](https://epicvin.com/license-plate-lookup)| VIN/plate search tool (US) |
+| [Mexico.gob](http://www2.repuve.gob.mx:8080/ciudadania/servletconsulta) | Mexico license plate search tool |
+| [Ghana Opera News](https://gh.opera.news/gh/en/auto/c4c2fcb2873ee5c189b5ede517b93edd) | list of Ghana license platea area codes |
+| [MPWT.gov](https://www.mpwt.gov.kh/en/home) | search tool for Cambodian number plates (must use VPN to access) |
+| [Parkingfee.gov](https://parkingfee.pma.gov.taipei/Fee/EnQuery) | shows information if parking fee is associated with number plate(Taipei) |
+| [TTCarLicense](https://apps.apple.com/us/app/ttcarlicense/id1450083022) | Myanmar license plate search app for macOS |
+| [EpicVin.com](https://epicvin.com/license-plate-lookup) | VIN/plate search tool (US) |
 | [AuthorandBookinfo.com](http://www.authorandbookinfo.com/kingkong/where/dz.htm) | list of Algeria license plate area codes |
-| [Cardotcheck.co.uk](https://cardotcheck.co.uk/car-Import-check)| UK import search by registration number/license plate |
-| [Freecarcheck.co.uk](https://www.freecarcheck.co.uk/import-export-checks/)| UK import search by registration number/license plate |
-|[vvo.at](https://www.vvo.at/vvo/vvo.nsf/sysPages/versichererauskunft.html)| Austria plate search (insurance verficiation and other info) |
-|[bzkbih.ba](https://www.bzkbih.ba/en/stream.php?kat=101&kat=101)| Bosnia plate search (insurance verficiation and other info) |
-|[huo.hr](https://huo.hr/hr/provjera-osiguranja)| Croatia insurance verification search by plate |
-|[ic.ckp.cz](https://ic.ckp.cz/ICwww/servlet?_page=searchSPZ&amp;lngID=2)| Czech Republic insurance verification by plate |
-|[dfim.dk](https://www.dfim.dk/garantifonde/garantifond-motorkoeretoejer/uheld-i-danmark/er-koeretoejet-forsikret/)| Denmark insurance verification by plate |
-|[vs.lkf.ee](https://vs.lkf.ee/pls/xlk/!sysadm.ic_insurance_cover_pkt.show_form?p_purpose=CLAIM&p_lang=ENG)| Estonia/RU/Iran insurance verification by plate/vin/date of interest/accident |
-|[claimsic.fi](https://www.claimsic.fi/#!/search)| Finlad insurance verification (must include victim vehicle info) |
-|[services.ltab.lv](https://services.ltab.lv/lv/RespInsurer)| Latvia insurance verification |
-|[cab.lt](https://www.cab.lt/draustumo-patikra)| Lithuania insurance verification |
-|[ufg.pl](https://www.ufg.pl/infoportal/faces/pages_home-page/Page_4d98135c_14e2b8ace27__7ff1/Pagee0e22f3_14efe6adc05__7ff1/Page4d024e07_14f0a824115__7ff6?_afrLoop=5843720732967066&amp%3B_afrWindowMode=0&amp%3B_adf.ctrl-state=uqbl5vp5w_50&_afrWindowMode=0&_adf.ctrl-state=erlmwsizz_4)| Poland insurance verification by plate |
-|[raz.zav](https://raz.zav-zdruzenje.si/euinfocenter/Search.aspx)| Slovania insurance verification |
-|[tff.se](https://www.tff.se/en/For-insurance-companies/Insurance-check/)| Swedan insurance verification by plate |
-| [Wulling.id](https://wuling.id/en/blog/lifestyle/indonesian-vehicle-registration-plates#) | Article on indonesian license plate information including region codes and plate types |
+| [Cardotcheck.co.uk](https://cardotcheck.co.uk/car-Import-check) | UK import search by registration number/license plate |
+| [Freecarcheck.co.uk](https://www.freecarcheck.co.uk/import-export-checks/) | UK import search by registration number/license plate |
+| [vvo.at](https://www.vvo.at/vvo/vvo.nsf/sysPages/versichererauskunft.html) | Austria plate search (insurance verification and other info) |
+| [bzkbih.ba](https://www.bzkbih.ba/en/stream.php?kat=101&kat=101)| Bosnia plate search (insurance verification and other info) |
+| [huo.hr](https://huo.hr/hr/provjera-osiguranja) | Croatia insurance verification search by plate |
+| [ic.ckp.cz](https://ic.ckp.cz/ICwww/servlet?_page=searchSPZ&amp;lngID=2) | Czech Republic insurance verification by plate |
+| [dfim.dk](https://www.dfim.dk/garantifonde/garantifond-motorkoeretoejer/uheld-i-danmark/er-koeretoejet-forsikret/) | Denmark insurance verification by plate |
+| [vs.lkf.ee](https://vs.lkf.ee/pls/xlk/!sysadm.ic_insurance_cover_pkt.show_form?p_purpose=CLAIM&p_lang=ENG) | Estonia/RU/Iran insurance verification by plate/vin/date of interest/accident |
+| [claimsic.fi](https://www.claimsic.fi/#!/search) | Finland insurance verification (must include victim vehicle info) |
+| [services.ltab.lv](https://services.ltab.lv/lv/RespInsurer) | Latvia insurance verification |
+| [cab.lt](https://www.cab.lt/draustumo-patikra) | Lithuania insurance verification |
+| [ufg.pl](https://www.ufg.pl/infoportal/faces/pages_home-page/Page_4d98135c_14e2b8ace27__7ff1/Pagee0e22f3_14efe6adc05__7ff1/Page4d024e07_14f0a824115__7ff6?_afrLoop=5843720732967066&amp%3B_afrWindowMode=0&amp%3B_adf.ctrl-state=uqbl5vp5w_50&_afrWindowMode=0&_adf.ctrl-state=erlmwsizz_4) | Poland insurance verification by plate |
+| [raz.zav](https://raz.zav-zdruzenje.si/euinfocenter/Search.aspx) | Slovania insurance verification |
+| [tff.se](https://www.tff.se/en/For-insurance-companies/Insurance-check/) | Swedan insurance verification by plate |
+| [Wulling.id](https://wuling.id/en/blog/lifestyle/indonesian-vehicle-registration-plates#) | Article on Indonesian license plate information including region codes and plate types |
 | [Turizm.net](https://www.turizm.net/turkey/citycodesofturkey.html) | City codes for Turkish number plates |
 | [aida.info](https://www.aida.info.ro/polite-rca) | Romania insurance verification by license plate or VIN number |
-|[Egypt.gov](https://traffic.moi.gov.eg/English/OurServices/InfoServices/InteriorMinisterDecision/Pages/license-plates-taxes-traffic-fees.aspx)| Chart of license plate specifications based on vehicle type |
+| [Egypt.gov](https://traffic.moi.gov.eg/English/OurServices/InfoServices/InteriorMinisterDecision/Pages/license-plates-taxes-traffic-fees.aspx) | Chart of license plate specifications based on vehicle type |
 
 
 ### VIN Tools
@@ -101,25 +101,25 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | [Vindecoderz](https://www.vindecoderz.com/) | free VIN decoder |
 | [Bimmwer.work](https://bimmer.work/) | bmw specific VIN decoder with full optional list
 | [Ford Vin Search](https://www.fordvinlookup.com/)| Ford VIN decoder |
-| [Chevrolet Vin Search](https://chevroletforum.com/forum/vindecoder.php)| Chevy VIN decoder |
-| [Hyundai Vin Search](https://www.hyundaiforum.com/forum/vindecoder.php)| Hyuandai VIN decoder |
-| [Nissan Vin Search](https://www.nissanusa.com/recalls-vin.html)| Nissan VIN decoder |
+| [Chevrolet Vin Search](https://chevroletforum.com/forum/vindecoder.php) | Chevy VIN decoder |
+| [Hyundai Vin Search](https://www.hyundaiforum.com/forum/vindecoder.php) | Hyuandai VIN decoder |
+| [Nissan Vin Search](https://www.nissanusa.com/recalls-vin.html) | Nissan VIN decoder |
 | [Cadillac Vin Search](https://www.cadillacforum.com/forum/vindecoder.php)| Caddillac VIN decoder |
-| [Dodge Vin Search](https://dodgeforum.com/forum/vindecoder.php)| Dodge VIN decode |
-| [Toyota Vin Search](https://www.toyota.com/owners/my-vehicle/vehicle-specification.html)| Toyota VIN decoder |
-| [Audi Vin Search](https://www.audiworld.com/forums/vindecoder.php)| Audi VIN decoder |
+| [Dodge Vin Search](https://dodgeforum.com/forum/vindecoder.php) | Dodge VIN decode |
+| [Toyota Vin Search](https://www.toyota.com/owners/my-vehicle/vehicle-specification.html) | Toyota VIN decoder |
+| [Audi Vin Search](https://www.audiworld.com/forums/vindecoder.php) | Audi VIN decoder |
 | [Honda Vin Search](https://estore.honda.com/honda/parts/use-your-vehicle-vin.asp)| Honda VIN decoder |
-| [Yamaha Vin Search](https://vinpit.com/vin-decoder/yamaha)| Yamaha VIN decoder |
+| [Yamaha Vin Search](https://vinpit.com/vin-decoder/yamaha) | Yamaha VIN decoder |
 | [Kawasaki Vin Search](https://vinpit.com/vin-decoder/kawasaki) | Kawasaki VIN decoder |
 | [Scion Vin Search](https://www.scionlife.com/forums/vindecoder.php) | Scion VIN decoder |
 | [National Highway Safety Administration](https://www.nhtsa.gov/vin-decoder) | NHTSA VIN decoder |
 | [GM Vin Search](https://www.gmforum.com/vindecoder.php) | General Motors VIN decoder |
-| [BigRig](https://bigrigvin.com/) | Big-rig (Semi-trucks and large commercial vehicles) vin decoder/search |
-| [Cartell.ie](https://www.cartell.ie/japanese-import/)| registry for japanese vehicles, shows import/ previous owners by VIN |
-| [Carvx.jp](https://carvx.jp/)| vehicle check by chasis number (Japan) |
-| [Vinpit.com](https://vinpit.com/vin-check/rv-motorhome)| RV/Motorhome VIN lookup |
-| [Cyclevin.com](https://cyclevin.com/)| VIN database more focused on stolen off and on road motorcycles/bikes |
-| [ATVStyle.com](https://www.atvstyle.com/atv-vin-check-free-atv-vin-decoder/)| VIN decoder for ATV |
+| [BigRig](https://bigrigvin.com/) | Big-rig (Semi-trucks and large commercial vehicles) VIN decoder/search |
+| [Cartell.ie](https://www.cartell.ie/japanese-import/) | registry for Japanese vehicles, shows import/ previous owners by VIN |
+| [Carvx.jp](https://carvx.jp/) | vehicle check by chasis number (Japan) |
+| [Vinpit.com](https://vinpit.com/vin-check/rv-motorhome) | RV/Motorhome VIN lookup |
+| [Cyclevin.com](https://cyclevin.com/) | VIN database more focused on stolen off-road and on-road motorcycles/bikes |
+| [ATVStyle.com](https://www.atvstyle.com/atv-vin-check-free-atv-vin-decoder/) | VIN decoder for ATV |
 | [pro.rarom.ro](https://pro.rarom.ro/istoric_vehicul/dosar_vehicul.aspx) | Romania vehicle history by VIN number |
 
 ### Map/Street View Tools/Streetcams
@@ -127,50 +127,50 @@ A comprehensive list of websites, add-ons, repositories, and other tools useful 
 | --- | --- |
 | [Show My Street](https://showmystreet.com/) | simplifies google street view and maps with one straightforward interface |
 | [Mapillary](https://www.mapillary.com/app/) | overview map of street panoramas around the world |
-| [WebcamTaxi](https://www.webcamtaxi.com/en/webcams.html) | livestreams web/security cameras around the world, including interactive map of camera locations |
+| [WebcamTaxi](https://www.webcamtaxi.com/en/webcams.html) | livestreams web/security cameras around the world, including an interactive map of camera locations |
 | [EarthCam](https://www.earthcam.com/) | live webcam network with cameras around the world |
 | [WorldCam.eu](https://worldcam.eu/) | live webcam network with cameras around the world |
 | [Magonolialinkworld](https://www.mangolinkworld.com/) | live webcam network with cameras around the world |
 | [WorldCams](https://worldcams.tv/) | live webcam network with cameras around the world |
-| [Google Map Scraper](https://console.apify.com/actors/nwua9Gu5YrADL7ZDj) | scrapes addresses, phone numbers, etc from google map data |
+| [Google Map Scraper](https://console.apify.com/actors/nwua9Gu5YrADL7ZDj) | scrapes addresses, phone numbers, etc from Google Maps data |
 | [Cipher's Public Transport Maps](https://cipher387.github.io/public_transport_maps/) | 20 public transport maps around the world |
 | [Open Aerial Map](https://map.openaerialmap.org/#/-18.45703125,18.47960905583197,3?_k=3dgcbd) | overhead aerial view of locations around the world |
 | [ArcGis](https://www.arcgis.com/apps/View/index.html?appid=b3a7a2930b974773ba28968710fec0d3) | map of semi-truck routes in US |
 | [Bureau of Transportation](https://www.bts.gov/product/geospatial-application-and-map-gallery) | Bureau of Transportation public maps |
 | [Transport for London](https://tfl.gov.uk/maps/bus) | London bus map |
 | [TransitMap](https://transitmap.net/) | current and past international transit map archives |
-[Indonesia Region Code Map](https://www.reddit.com/r/indonesia/comments/22hzde/map_of_vehicle_registration_codes_of_indonesia/)| map of Indonesian region codes (map is older, but accurate as of Dec 2022) |
-|[allstays.com](https://www.allstays.com/c/truck-stop-locations.htm)| Truck stop map of North America |
-|[Driverwyze.com](https://drivewyze.com/coverage-map/)| Weigh Station Bypass Coverage Map for North America (lists all weigh stations and their current operational conditions) |
-|[Weatherbug](https://www.weatherbug.com/traffic-cam/)| live traffic camera/road condition map |
-|[Truck Parking Europe](https://app.truckparkingeurope.com/)| map of commercial truck parking in europe |
+| [Indonesia Region Code Map](https://www.reddit.com/r/indonesia/comments/22hzde/map_of_vehicle_registration_codes_of_indonesia/)| map of Indonesian region codes (map is older, but accurate as of Dec 2022) |
+| [allstays.com](https://www.allstays.com/c/truck-stop-locations.htm) | Truck stop map of North America |
+| [Driverwyze.com](https://drivewyze.com/coverage-map/) | Weigh Station Bypass Coverage Map for North America (lists all weigh stations and their current operational conditions) |
+| [Weatherbug](https://www.weatherbug.com/traffic-cam/) | live traffic camera/road condition map |
+| [Truck Parking Europe](https://app.truckparkingeurope.com/) | map of commercial truck parking in europe |
 
 ### Other Useful Tools
 | Link | Description |
 | --- | --- |
 | [Cipher's OSINT Map](https://cipher387.github.io/osintmap/) | Cipher's interactive map of useful online public/registry services by location and other great tools |
 | [iHunt](https://nitinpandey.in/ihunt/) | OSINT Framework |
-| [Check License Plates](https://www.icloud.com/shortcuts/1e500ea210244b62a35bd28912797a86) | iphone/ipad shortcut for searching plates based on country, state, or region |
+| [Check License Plates](https://www.icloud.com/shortcuts/1e500ea210244b62a35bd28912797a86) | iPhone/iPad shortcut for searching plates based on country, state, or region |
 | [CarInfo](https://apps.apple.com/in/app/car-info-vehicle-registration/id1146173741) | India license plate search for macOS/iOS |
-| [BGToll](https://check.bgtoll.bg/#/) | vignette check for EU, Russia, and Asia and Middle East |
+| [BGToll](https://check.bgtoll.bg/#/) | vignette check for EU, Russia, and Asia and the Middle East |
 | [PaperswithCode](https://paperswithcode.com/datasets?q=license+plates&v=lst&o=match&mod=images&page=1) | international license plate datasets with collections of images |
 | [NMVTIS](https://vehiclehistory.bja.ojp.gov/nmvtis_vehiclehistory#w7o24a) | NMVTIS approved data providers |
-| [DL # Calculator](http://www.highprogrammer.com/cgi-bin/uniqueid/dl_fl) | calculates DL numbers in 9 states based on first/MI/last, gender, and DOB based on the states method of DL # calculation. |
-| [Enterprise](https://www.enterprise.com/en/reserve/receipts.html?icid=header.reservations.car.rental-_-receipt-_-ENUS.NULL) | finds reciepts using last name/DL number combo |
-| [Hertz](https://www.hertz.com/rentacar/receipts/request-receipts.do) | finds reciepts using last name/DL number combo |
+| [DL # Calculator](http://www.highprogrammer.com/cgi-bin/uniqueid/dl_fl) | calculates DL numbers in 9 states based on first/MI/last, gender, and DOB based on the state's method of DL # calculation. |
+| [Enterprise](https://www.enterprise.com/en/reserve/receipts.html?icid=header.reservations.car.rental-_-receipt-_-ENUS.NULL) | finds receipts using last name/DL number combo |
+| [Hertz](https://www.hertz.com/rentacar/receipts/request-receipts.do) | finds receipts using last name/DL number combo |
 | [FMCSA.gov](https://www.fmcsa.dot.gov/safety/passenger-safety/search-results/by-company)| Passenger carrier search by comapany/vehicle |
-| [FindFreightLoads.com](https://findfreightloads.com/truck-drivers/find)| Commerical driver/load regsitry with list of available drivers and loads (contact info with registered account) |
-| [FMCSA.gov](https://safer.fmcsa.dot.gov/CompanySnapshot.aspx)| can search company safety records by USDOT number, MC/Mx Number, or company name |
-| [ATVTrader.com](https://www.atvtrader.com/ATVs-by-Make/atvs-for-sale?vrsn=links&format=make)| database of over 1,000,000 ATV's for sale with pictures |
-| [AutoEvolution.com](https://www.autoevolution.com/moto/)| ATV/Motorcycle timeline by manufacturer with pictures all brand associated models (other vehicle timelines as well) |
-| [MXSouth.com](https://www.mxsouth.com/atv/brands.htm)| All known ATV manufacturers/accessory brands |
-| [NHTSA.gov](https://www.nhtsa.gov/importing-vehicle/registered-importers)| All registered US vehicle importers |
-|[Biology junction](https://biologyjunction.com/library-of-tire-tread-patterns/)| Library of Tire Tread Patterns |
-|[Tire Review](https://www.tirereview.com/reading-tire-wear-patterns/#:~:text=Tire%20wear%20in%20the%20center,carry%20all%20of%20the%20load.&text=Tire%20wear%20on%20the%20edges,pressures%20are%20lower%20than%20specified.)| Article on how to spot details about a vehicles operation condition from tire tread wear. |
-|[CarLogos.com](https://www.carlogos.org/reviews/largest-tire-manufacturers.html)| Complete list of largest tire manufacturers in the world |
-|[List of Companies.com](https://www.listofcompaniesin.com/product-s/atv-tire.html)| List of ATV specific tire manufacturers |
-|[Thomasnet.com](https://www.thomasnet.com/products/trailer-hitches-96117700-1.html)| list of 113 known US hitch trailer manufacturers |
-|[NHTSA](https://www.nhtsa.gov/recalls)| U.S Vehicle & equipment registry for safety issues/recalls by VIN |
+| [FindFreightLoads.com](https://findfreightloads.com/truck-drivers/find) | Commercial driver/load registry with list of available drivers and loads (contact info with registered account) |
+| [FMCSA.gov](https://safer.fmcsa.dot.gov/CompanySnapshot.aspx) | can search company safety records by USDOT number, MC/Mx Number, or company name |
+| [ATVTrader.com](https://www.atvtrader.com/ATVs-by-Make/atvs-for-sale?vrsn=links&format=make) | database of over 1,000,000 ATV's for sale with pictures |
+| [AutoEvolution.com](https://www.autoevolution.com/moto/) | ATV/Motorcycle timeline by manufacturer with pictures all brand-associated models (other vehicle timelines as well) |
+| [MXSouth.com](https://www.mxsouth.com/atv/brands.htm) | All known ATV manufacturers/accessory brands |
+| [NHTSA.gov](https://www.nhtsa.gov/importing-vehicle/registered-importers) | All registered US vehicle importers |
+| [Biology junction](https://biologyjunction.com/library-of-tire-tread-patterns/) | Library of Tire Tread Patterns |
+| [Tire Review](https://www.tirereview.com/reading-tire-wear-patterns/#:~:text=Tire%20wear%20in%20the%20center,carry%20all%20of%20the%20load.&text=Tire%20wear%20on%20the%20edges,pressures%20are%20lower%20than%20specified.) | Article on how to spot details about a vehicle's operational condition from tire tread wear. |
+| [CarLogos.com](https://www.carlogos.org/reviews/largest-tire-manufacturers.html) | Complete list of largest tire manufacturers in the world |
+| [List of Companies.com](https://www.listofcompaniesin.com/product-s/atv-tire.html) | List of ATV specific tire manufacturers |
+| [Thomasnet.com](https://www.thomasnet.com/products/trailer-hitches-96117700-1.html) | list of 113 known US hitch trailer manufacturers |
+| [NHTSA](https://www.nhtsa.gov/recalls) | U.S Vehicle & equipment registry for safety issues/recalls by VIN |
 
 ### Additional Resources/Notes
 - Local police impound registries (county, state, or province)


### PR DESCRIPTION
The link for idahoaccess moved to tyleridaho.
Some additional spelling and grammar corrections as well.